### PR TITLE
Fix for duplicate events randomly occurring

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -507,21 +507,25 @@ function processEventInstance(recEvent){
 
 /**
  * Deletes all events from the target calendar that no longer exist in the source calendars.
+ * Also deletes duplicate events on target calendar that may have been introduced by a script read error
  * If onlyFutureEvents is set to true, events that have taken place since the last sync are also removed.
  */
 function processEventCleanup(){
+  var processedIndex = []; // ensure no duplicates on Google Calendar
   for (var i = 0; i < calendarEvents.length; i++){
       var currentID = calendarEventsIds[i];
       var feedIndex = icsEventsIds.indexOf(currentID);
       
-      if(feedIndex  == -1 && calendarEvents[i].recurringEventId == null){
-        Logger.log("Deleting old event " + currentID);
+      if(processedIndex.indexOf(currentID) != -1 || feedIndex  == -1 && calendarEvents[i].recurringEventId == null){
+        Logger.log("Deleting event " + currentID + " (clean up)");
         try{
           Calendar.Events.remove(targetCalendarId, calendarEvents[i].id);
         }
         catch (err){
           Logger.log(err);
         }
+      } else {
+        processedIndex.push(currentID);
       }
     }
 }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -516,7 +516,7 @@ function processEventCleanup(){
       var currentID = calendarEventsIds[i];
       var feedIndex = icsEventsIds.indexOf(currentID);
       
-      if(processedIndex.indexOf(currentID) != -1 || feedIndex  == -1 && calendarEvents[i].recurringEventId == null){
+      if((feedIndex  == -1 && calendarEvents[i].recurringEventId == null) || processedIndex.indexOf(currentID) != -1){
         Logger.log("Deleting event " + currentID + " (clean up)");
         try{
           Calendar.Events.remove(targetCalendarId, calendarEvents[i].id);


### PR DESCRIPTION
Somehow over the weeks, it seems once in a while, a sync event just creates duplicates of every single event in the ics file. These will never be deleted by the script.

Now sure if anyone has also experienced this but it's difficult to reproduce. I'm thinking it's some weird calendar read error when the script thinks there are no events in the target calendar at a given moment.

This PR introduces a more aggressive clean up which also deletes any duplicate events in the target calendar.