### PR TITLE
Fix for item.originalStartTime being undefined

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -490,6 +490,7 @@ function processEventInstance(recEvent){
     }).items;
 
   var eventInstanceToPatch = calendarEvents.filter(function(item){
+    if (!item.originalStartTime) return false
     var origStart = item.originalStartTime.dateTime || item.originalStartTime.date;
     var instanceStart = new ICAL.Time.fromString(origStart);
 


### PR DESCRIPTION
I sometimes get this otherwise:

```js
TypeError: Cannot read property 'dateTime' of undefined
    at [unknown function](Helpers:493:44)
    at processEventInstance(Helpers:492:45)
    at startSync(Code:139:7)
```

in 

https://github.com/derekantrican/GAS-ICS-Sync/blob/763f219a9e0162befcd332eb930271bcf0b81132/Helpers.gs#L492-L497