### PR TITLE
Update comments in Code.gs and improve update check

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -18,9 +18,10 @@
 
 var sourceCalendars = [                // The ics/ical urls that you want to get events from along with their target calendars (list a new row for each mapping of ICS url to Google Calendar)
                                        // For instance: ["https://www.calendarlabs.com/ical-calendar/ics/76/US_Holidays.ics", "US Holidays"]
+                                       // If you want to sync to your main Google Calendar, use your Gmail email address for targetCalendar1
   ["icsUrl1", "targetCalendar1"],
   ["icsUrl2", "targetCalendar2"],
-  ["icsUrl3", "targetCalendar1"]
+  ["icsUrl3", "targetCalendar3"]
   
 ];
 
@@ -39,7 +40,7 @@ var defaultAllDayReminder = -1;        // Default reminder for all day events in
 var addTasks = false;
 
 var emailSummary = false;              // Will email you when an event is added/modified/removed to your calendar
-var email = "";                        // OPTIONAL: If "emailWhenAdded" is set to true, you will need to provide your email
+var email = "";                        // OPTIONAL: If "emailSummary" is set to true or you want to receive update notifications, you will need to provide your email address
 
 /*
 *=========================================

--- a/Code.gs
+++ b/Code.gs
@@ -18,10 +18,9 @@
 
 var sourceCalendars = [                // The ics/ical urls that you want to get events from along with their target calendars (list a new row for each mapping of ICS url to Google Calendar)
                                        // For instance: ["https://www.calendarlabs.com/ical-calendar/ics/76/US_Holidays.ics", "US Holidays"]
-                                       // If you want to sync to your main Google Calendar, use your Gmail email address for targetCalendar1
   ["icsUrl1", "targetCalendar1"],
   ["icsUrl2", "targetCalendar2"],
-  ["icsUrl3", "targetCalendar3"]
+  ["icsUrl3", "targetCalendar1"]
   
 ];
 

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -829,24 +829,30 @@ function callWithBackoff(func, maxRetries) {
  * Will notify the user once if a new version was released.
  */
 function checkForUpdate(){
-  var alreadyAlerted = PropertiesService.getScriptProperties().getProperty("alertedForNewVersion");
-  if (alreadyAlerted == null){
-    try{
-      var thisVersion = 5.4;
-      var html = UrlFetchApp.fetch("https://github.com/derekantrican/GAS-ICS-Sync/releases");
-      var regex = RegExp("<a.*title=\"\\d\\.\\d\">","g");
-      var latestRelease = regex.exec(html)[0];
-      regex = RegExp("\"(\\d.\\d)\"", "g");
-      var latestVersion = Number(regex.exec(latestRelease)[1]);
-      
-      if (latestVersion > thisVersion){
-        if (email != ""){
-          GmailApp.sendEmail(email, "New version of GAS-ICS-Sync is available!", "There is a new version of \"GAS-ICS-Sync\". You can see the latest release here: https://github.com/derekantrican/GAS-ICS-Sync/releases");
-        
-          PropertiesService.getScriptProperties().setProperty("alertedForNewVersion", true);
-        }
-      }
+  // No need to check if we can't alert anyway
+  if (email == "")
+    return;
+
+  var lastAlertedVersion = PropertiesService.getScriptProperties().getProperty("alertedForNewVersion");
+  try {
+    var thisVersion = 5.4;
+    var latestVersion = getLatestVersion();
+
+    if (latestVersion > thisVersion && latestVersion != lastAlertedVersion){
+      GmailApp.sendEmail(email,
+        `Version ${latestVersion} of GAS-ICS-Sync is available! (You have ${thisVersion})`,
+        "You can see the latest release here: https://github.com/derekantrican/GAS-ICS-Sync/releases");
+
+      PropertiesService.getScriptProperties().setProperty("alertedForNewVersion", latestVersion);
     }
-    catch(e){}
+  }
+  catch (e){}
+
+  function getLatestVersion(){
+    var html = UrlFetchApp.fetch("https://github.com/derekantrican/GAS-ICS-Sync/releases");
+    var regex = RegExp("<a.*title=\"\\d\\.\\d\">", "g");
+    var latestRelease = regex.exec(html)[0];
+    regex = RegExp("\"(\\d.\\d)\"", "g");
+    return Number(regex.exec(latestRelease)[1]);
   }
 }


### PR DESCRIPTION
Based on [my comment](https://github.com/derekantrican/GAS-ICS-Sync/pull/17#discussion_r518390756) to #17 I updated the the `email` comment in `Code.gs` and changed `checkForUpdate` in `Helpers.gs`.

`checkForUpdate` will now send a notification email again if a _newer_ version becomes available, but most importantly it **takes a shortcut** and exits if no email address is set anyway (thus reducing queries to GitHub and potentially execution time a bit :-)).

The new behavior is like this (assuming user has v5.4 installed and email variable is set):
* v5.5 gets released --> User gets notification: "Version 5.5 of GAS-ICS-Sync is available! (You have 5.4)"
* v5.6 gets released --> User gets another notification: "Version 5.6 of GAS-ICS-Sync is available! (You have 5.4)"