### PR TITLE
Skip (don't clear entries)if the calendar url address is unavailable,

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -24,6 +24,7 @@ var sourceCalendars = [                // The ics/ical urls that you want to get
   
 ];
 
+var skipIfUrlUnavailable = false;
 var howFrequent = 15;                  // What interval (minutes) to run this script on to check for new events
 var onlyFutureEvents = false;          // If you turn this to "true", past events will not be synced (this will also removed past events from the target calendar if removeEventsFromCalendar is true)
 var addEventsToCalendar = true;        // If you turn this to "false", you can check the log (View > Logs) to make sure your events are being read correctly before turning this on
@@ -137,7 +138,7 @@ function startSync(){
     var vevents;
     //------------------------ Fetch URL items ------------------------
     var responses = fetchSourceCalendars(sourceCalendarURLs);
-    if (responses.length == 0){
+    if (responses.length == 0 && skipIfUrlUnavailable){
       Logger.log("Skipping " + targetCalendarName);
       continue;
     }

--- a/Code.gs
+++ b/Code.gs
@@ -137,6 +137,10 @@ function startSync(){
     var vevents;
     //------------------------ Fetch URL items ------------------------
     var responses = fetchSourceCalendars(sourceCalendarURLs);
+    if (responses.length == 0){
+      Logger.log("Skipping " + targetCalendarName);
+      continue;
+    }
     Logger.log("Syncing " + responses.length + " calendars to " + targetCalendarName);
     
     //------------------------ Get target calendar information------------------------


### PR DESCRIPTION
Maybe some people have ics files on servers that are not always available.

If the url is not available, then don't delete all the entries - just skip that calendar.

This PR is not a solution to the original issue discussed here: https://github.com/derekantrican/GAS-ICS-Sync/issues/155
however, in my opinion it is a good idea, not to delete all the stuff if the server is unavailable. This creates an option *skipIfUrlUnavailable* . By default this is set to false - so the behavior is unchanged; however, if the user sets this to true, entries in a calendar will not be deleted if the url is not available.

I'm not sure if my implementation is ideal. It works for me, but it is likely that other will have suggestions to improve before this actually gets merged, if it ever does.

