### PR TITLE
Let installation errors bubble up so they're logged and fix callWithBackoff

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -86,13 +86,12 @@ var email = "";                        // OPTIONAL: If "emailSummary" is set to 
 //!!!!!!!!!!!!!!!! DO NOT EDIT BELOW HERE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING !!!!!!!!!!!!!!!!!!!!
 //=====================================================================================================
 function install(){
-  callWithBackoff(function() {
-    //Delete any already existing triggers so we don't create excessive triggers
-    deleteAllTriggers();
-    
-    ScriptApp.newTrigger("startSync").timeBased().everyMinutes(getValidTriggerFrequency(howFrequent)).create(); //Schedule sync routine to explicitly repeat
-    ScriptApp.newTrigger("startSync").timeBased().after(1000).create();//Start the sync routine
-  }, 5);  // Retry max. 5 times
+  //Delete any already existing triggers so we don't create excessive triggers
+  deleteAllTriggers();
+
+  //Schedule sync routine to explicitly repeat and schedule the initial sync
+  ScriptApp.newTrigger("startSync").timeBased().everyMinutes(getValidTriggerFrequency(howFrequent)).create();
+  ScriptApp.newTrigger("startSync").timeBased().after(1000).create();
 }
 
 function uninstall(){

--- a/Code.gs
+++ b/Code.gs
@@ -86,15 +86,13 @@ var email = "";                        // OPTIONAL: If "emailSummary" is set to 
 //!!!!!!!!!!!!!!!! DO NOT EDIT BELOW HERE UNLESS YOU REALLY KNOW WHAT YOU'RE DOING !!!!!!!!!!!!!!!!!!!!
 //=====================================================================================================
 function install(){
-  try{
+  callWithBackoff(function() {
     //Delete any already existing triggers so we don't create excessive triggers
     deleteAllTriggers();
     
     ScriptApp.newTrigger("startSync").timeBased().everyMinutes(getValidTriggerFrequency(howFrequent)).create(); //Schedule sync routine to explicitly repeat
     ScriptApp.newTrigger("startSync").timeBased().after(1000).create();//Start the sync routine
-  }catch(e){
-    install();//Retry on error
-  }
+  }, 5);  // Retry max. 5 times
 }
 
 function uninstall(){

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -833,18 +833,25 @@ function sendSummary() {
  */
 function callWithBackoff(func, maxRetries) {
   var tries = 0;
+  var timeout = 100;
   var result;
-  do{
-    Utilities.sleep(tries * 100);
+  while(tries < maxRetries){
     tries++;
     try{
       result = func();
       return result;
     }
     catch(e){
-      Logger.log("Error, Retrying..." + e );
+      if (tries < maxRetries){
+        Logger.log(`Error, retrying in ${timeout}ms... [${e}]`);
+        Utilities.sleep(timeout);
+        timeout*=2; // Exponentially increase timeout
+      }
+      else {
+        Logger.log(`Error, giving up after trying ${maxRetries} times [${e}]`);
+      }
     }
-  }while(tries <= maxRetries );
+  }
 
   return null;
 }


### PR DESCRIPTION
Use the existing `callWithBackoff` method in `Helpers.gs` to limit retrying the script installation to 5 times, exponentially increasing the wait time between retries. This also gives us logging of errors during the installation.

Additionally, `callWithBackoff` is modified to do what it says on the tin and provide exponential backoff times (starting with 100ms, then 200ms, 400ms, etc.). 