### PR TITLE
Fix bug with recurring events and multiple calendars.

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -98,8 +98,9 @@ function uninstall(){
   deleteAllTriggers();
 }
 
-var targetCalendarId;
-var targetCalendarName;
+var startUpdateTime;
+
+// Per-calendar global variables (must be reset before processing each new calendar!)
 var calendarEvents = [];
 var calendarEventsIds = [];
 var icsEventsIds = [];
@@ -108,7 +109,8 @@ var recurringEvents = [];
 var addedEvents = [];
 var modifiedEvents = [];
 var removedEvents = [];
-var startUpdateTime;
+var targetCalendarId;
+var targetCalendarName;
 
 function startSync(){
   if (PropertiesService.getScriptProperties().getProperty('LastRun') > 0 && (new Date().getTime() - PropertiesService.getScriptProperties().getProperty('LastRun')) < 360000) {
@@ -128,10 +130,20 @@ function startSync(){
   
   sourceCalendars = condenseCalendarMap(sourceCalendars);
   for (var calendar of sourceCalendars){
+    //------------------------ Reset globals ------------------------
     calendarEvents = [];
+    calendarEventsIds = [];
+    icsEventsIds = [];
+    calendarEventsMD5s = [];
+    recurringEvents = [];
+    addedEvents = [];
+    modifiedEvents = [];
+    removedEvents = [];
+
     targetCalendarName = calendar[0];
     var sourceCalendarURLs = calendar[1];
     var vevents;
+
     //------------------------ Fetch URL items ------------------------
     var responses = fetchSourceCalendars(sourceCalendarURLs);
     Logger.log("Syncing " + responses.length + " calendars to " + targetCalendarName);


### PR DESCRIPTION
The `recurringEvents` array was not being reset on each new calendar.
This would cause "calendar contamination" when using this script with
more than one Google Calendar, as any recurring events processed on the
first calendar would also end up added to the second calendar.

Out of an abundance of caution, I've added a section of code in the main
loop that resets all "per-calendar" global variables. Longer-term, we
might think about how to factor the global variables out entirely.