### PR TITLE
Update getLastestVersion function

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -881,10 +881,9 @@ function checkForUpdate(){
   catch (e){}
 
   function getLatestVersion(){
-    var html = UrlFetchApp.fetch("https://github.com/derekantrican/GAS-ICS-Sync/releases");
-    var regex = RegExp("<a.*title=\"\\d\\.\\d\">", "g");
-    var latestRelease = regex.exec(html)[0];
-    regex = RegExp("\"(\\d.\\d)\"", "g");
-    return Number(regex.exec(latestRelease)[1]);
+    var json_encoded = UrlFetchApp.fetch("https://api.github.com/repos/derekantrican/GAS-ICS-Sync/releases?per_page=1");
+    json_decoded = JSON.parse(json_encoded);
+    var version = json_decoded[0]["tag_name"]
+    Logger.log("Version: " + version)
   }
 }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -883,7 +883,6 @@ function checkForUpdate(){
   function getLatestVersion(){
     var json_encoded = UrlFetchApp.fetch("https://api.github.com/repos/derekantrican/GAS-ICS-Sync/releases?per_page=1");
     json_decoded = JSON.parse(json_encoded);
-    var version = json_decoded[0]["tag_name"]
-    Logger.log("Version: " + version)
+    var version = json_decoded[0]["tag_name"];
   }
 }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -884,5 +884,6 @@ function checkForUpdate(){
     var json_encoded = UrlFetchApp.fetch("https://api.github.com/repos/derekantrican/GAS-ICS-Sync/releases?per_page=1");
     json_decoded = JSON.parse(json_encoded);
     var version = json_decoded[0]["tag_name"];
+    return Number(version);
   }
 }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -882,7 +882,7 @@ function checkForUpdate(){
 
   function getLatestVersion(){
     var json_encoded = UrlFetchApp.fetch("https://api.github.com/repos/derekantrican/GAS-ICS-Sync/releases?per_page=1");
-    json_decoded = JSON.parse(json_encoded);
+    var json_decoded = JSON.parse(json_encoded);
     var version = json_decoded[0]["tag_name"];
     return Number(version);
   }


### PR DESCRIPTION
Update getLatestVersion function to use GitHub APIs.
I think it's better then parse HTML with RegExps.
Let me know