### PR TITLE
Ignore all d ay events

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -41,6 +41,7 @@ var addCalToTitle = false;             // Whether to add the source calendar to 
 var addAttendees = false;              // Whether to add the attendee list. If true, duplicate events will be automatically added to the attendees' calendar.
 var defaultAllDayReminder = -1;        // Default reminder for all day events in minutes before the day of the event (-1 = no reminder, the value has to be between 0 and 40320)
                                        // See https://github.com/derekantrican/GAS-ICS-Sync/issues/75 for why this is neccessary.
+var ignoreAllDayEvents = false;        // Whether to add All-day events
 var addTasks = false;
 
 var emailSummary = false;              // Will email you when an event is added/modified/removed to your calendar

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -260,6 +260,9 @@ function createEvent(event, calendarTz){
 
   var newEvent = Calendar.newEvent();
   if(icalEvent.startDate.isDate){ //All-day event
+    if (ignoreAllDayEvents) {
+      return;
+    }
     if (icalEvent.startDate.compare(icalEvent.endDate) == 0){
       //Adjust dtend in case dtstart equals dtend as this is not valid for allday events
       icalEvent.endDate = icalEvent.endDate.adjust(1,0,0,0);


### PR DESCRIPTION
Some of my calendars contain all day events for bank holidays which makes a mess with several duplicate events.