### PR TITLE
Add Webhook support

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -110,6 +110,16 @@ function uninstall(){
   deleteAllTriggers();
 }
 
+function doGet(e) {
+  startSync();
+  return ContentService.createTextOutput(JSON.stringify({ "status": "ok" })).setMimeType(ContentService.MimeType.JSON); 
+}
+
+function doPost(e) {
+  startSync();
+  return ContentService.createTextOutput(JSON.stringify({ "status": "ok" })).setMimeType(ContentService.MimeType.JSON); 
+}
+
 var startUpdateTime;
 
 // Per-calendar global variables (must be reset before processing each new calendar!)


### PR DESCRIPTION
Sometimes, we can set up a webhook when ics/ical calendars change. It should be more efficient than the time-based trigger.