### PR TITLE
Update Code.gs > getPastDaysIfOnlyFutureEvents

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -31,6 +31,7 @@ var sourceCalendars = [                // The ics/ical urls that you want to get
 
 var howFrequent = 15;                  // What interval (minutes) to run this script on to check for new events
 var onlyFutureEvents = false;          // If you turn this to "true", past events will not be synced (this will also removed past events from the target calendar if removeEventsFromCalendar is true)
+var getPastDaysIfOnlyFutureEvents = 7; // If onlyFutureEvents is set to "true", you can get still some days in the past
 var addEventsToCalendar = true;        // If you turn this to "false", you can check the log (View > Logs) to make sure your events are being read correctly before turning this on
 var modifyExistingEvents = true;       // If you turn this to "false", any event in the feed that was modified after being added to the calendar will not update
 var removeEventsFromCalendar = true;   // If you turn this to "true", any event created by the script that is not found in the feed will be removed.
@@ -134,8 +135,10 @@ function startSync(){
   
   PropertiesService.getUserProperties().setProperty('LastRun', new Date().getTime());
   
+  var currentDate = new Date();
+  
   if (onlyFutureEvents)
-    startUpdateTime = new ICAL.Time.fromJSDate(new Date());
+    startUpdateTime = new ICAL.Time.fromJSDate(new Date(currentDate.setDate(currentDate.getDate() - getPastDaysIfOnlyFutureEvents)));
   
   //Disable email notification if no mail adress is provided 
   emailSummary = emailSummary && email != "";


### PR DESCRIPTION
Found a way to get past events, if onlyFutureEvents is set to true. Great for big calendars, which lead to timeouts. With this tweak, it is still possible to see some events in the past. 