### PR TITLE
Fix bug with rrules and n occurrences

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -516,6 +516,9 @@ function checkSkipEvent(event, icalEvent){
               mths += newStartDate.month - oldStartDate.month;
               ct -= mths;
             }
+            else if (v.freq=='YEARLY') {
+              ct -= newStartDate.year - oldStartDate.year;
+            }
             if (v.interval!=null) {
               ct /= v.interval;
             }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -502,6 +502,9 @@ function checkSkipEvent(event, icalEvent){
             if (ct==null){
               return;
             }
+            if (v.interval!=null) {
+              ct *= v.interval;
+            }
             if (v.freq=='DAILY') {
               ct -= diff.days;
             }
@@ -512,6 +515,9 @@ function checkSkipEvent(event, icalEvent){
               var mths = (newStartDate.year - oldStartDate.year) * 12;
               mths += newStartDate.month - oldStartDate.month;
               ct -= mths;
+            }
+            if (v.interval!=null) {
+              ct /= v.interval;
             }
             vals[i].count = ct;
           });


### PR DESCRIPTION
I noticed that If I have a recurring event which stops after n occurrences. The number of occurrences does not reduce with time but they are shifted.

I tested Monthly and Daily recurrences but not Weekly nor Yearly. I added support for INTERVAL as well.

To reproduce simply create a daily recurring event starting the day before but a bit later in the day than the current time and finishing after 4 occurrences. Run the script and you'll still see 4 events but starting one day later.

(I have the feeling this could be simplified a lot if the ICAL.RecurExpansion class could provide the total number of occurrences for time-limited recurrences)