### PR TITLE
add email prefix with time of sent email

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -49,6 +49,8 @@ var addTasks = false;
 
 var emailSummary = false;                 // Will email you when an event is added/modified/removed to your calendar
 var email = "";                           // OPTIONAL: If "emailSummary" is set to true or you want to receive update notifications, you will need to provide your email address
+var emailSummaryIncludeTime = true;       // OPTIONAL: If "emailSummary" is set to true, include whether to include timr as prefix.
+var emailSummaryTimeLocale = 'sv-SE';       // OPTIONAL: If "emailSummaryIncludeTime" is set to true, set the locale of the time prefix.
 
 /*
 *=========================================

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -885,6 +885,9 @@ function sendSummary() {
   var body;
 
   var subject = `GAS-ICS-Sync Execution Summary: ${addedEvents.length} new, ${modifiedEvents.length} modified, ${removedEvents.length} deleted`;
+  if (emailSummaryIncludeTime) {
+    subject = `[${new Date().toLocaleString(emailSummaryTimeLocale)}] ${subject}`;
+    }
   addedEvents = condenseCalendarMap(addedEvents);
   modifiedEvents = condenseCalendarMap(modifiedEvents);
   removedEvents = condenseCalendarMap(removedEvents);


### PR DESCRIPTION
Includes a time prefix for the email that is sent out. The time format (+ timezone) can  be customised using the `emailSummaryTimeLocale` variable.
The _'sv-SE'_ local results in the following format: `[2023-04-28 11:39:34] GAS-ICS-Sync Execution Summary: /.../`
