### PR TITLE
Change tentative MS365 events to sync as free

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -401,6 +401,10 @@ function createEvent(event, calendarTz){
       newEvent.transparency = transparency;
   }
 
+  if (event.getFirstPropertyValue('x-microsoft-cdo-busystatus')?.toString()?.toLowerCase() === "tentative") {
+    newEvent.transparency = "transparent";
+  }
+
   if (icalEvent.startDate.isDate){
     if (0 <= defaultAllDayReminder && defaultAllDayReminder <= 40320){
       newEvent.reminders = { 'useDefault' : false, 'overrides' : [{'method' : 'popup', 'minutes' : defaultAllDayReminder}]};//reminder as defined by the user


### PR DESCRIPTION
MS 365 has a concept of tentative: `X-MICROSOFT-CDO-BUSYSTATUS:TENTATIVE`.

GCal does not really have a concept of tentative. It uses `TRANSP:TRANSPARENT` to indicate that calendar space is "Free" and `TRANSP:OPAQUE` to indicate that calendar space is "Busy" (there is actually a "yes"/"no"/"maybe" option but it is only for shared events: `ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=TENTATIVE;CN=First Last;X-NUM-GUESTS=0:mailto:example@gmail.com`). `STATUS:TENTATIVE` events in GCal are shown as "Busy".

Tentative MS events are `TRANSP:OPAQUE`, so in order to make them not take up calendar space in GCal, they need to be set to `TRANSP:TRANSPARENT`.

IMO it is pretty reasonable for this change to be not configurable by the user because it helps achieve parity between GCal + MS, but I can add in a configuration variable if desired.
