### PR TITLE
Automatically repair incorrectly formatted ics files from Microsoft

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -81,13 +81,20 @@ function fetchSourceCalendars(sourceCalendarURLs){
       var urlResponse = UrlFetchApp.fetch(url, { 'validateHttpsCertificates' : false, 'muteHttpExceptions' : true });
       if (urlResponse.getResponseCode() == 200){
         var icsContent = urlResponse.getContentText()
-        var icsRegex = RegExp("(BEGIN:VCALENDAR.*?END:VCALENDAR)", "s")
+        const icsRegex = RegExp("(BEGIN:VCALENDAR.*?END:VCALENDAR)", "s")
         var urlContent = icsRegex.exec(icsContent);
-        if(urlContent == null) {
+        if (urlContent == null){
           // Microsoft Outlook has a bug that sometimes results in incorrectly formatted ics files. This tries to fix that problem.
-          icsContent = icsContent.replaceAll(/(?<!END:VTIMEZONE[\r\n]+)BEGIN:VEVENT/g, 'END:VEVENT\nBEGIN:VEVENT') + 'END:VCALENDAR'
+          // Add END:VEVENT for every BEGIN:VEVENT that's missing it
+          const veventRegex = /BEGIN:VEVENT(?:(?!END:VEVENT).)*?(?=.BEGIN|.END:VCALENDAR|$)/sg;
+          icsContent = icsContent.replace(veventRegex, (match) => match + "\nEND:VEVENT");
+
+          // Add END:VCALENDAR if missing
+          if (!icsContent.endsWith("END:VCALENDAR")){
+              icsContent += "\nEND:VCALENDAR";
+          }          
           urlContent = icsRegex.exec(icsContent)
-          if (urlContent == null) {
+          if (urlContent == null){
             Logger.log("[ERROR] Incorrect ics/ical URL: " + url)
             return
           }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -76,26 +76,32 @@ function fetchSourceCalendars(sourceCalendarURLs){
   for (var source of sourceCalendarURLs){
     var url = source[0].replace("webcal://", "https://");
     var colorId = source[1];
-
+    
     callWithBackoff(function() {
       var urlResponse = UrlFetchApp.fetch(url, { 'validateHttpsCertificates' : false, 'muteHttpExceptions' : true });
       if (urlResponse.getResponseCode() == 200){
-        var urlContent = RegExp("(BEGIN:VCALENDAR.*?END:VCALENDAR)", "s").exec(urlResponse.getContentText());
-        if(urlContent == null){
-          Logger.log("[ERROR] Incorrect ics/ical URL: " + url);
-          return;
+        var icsContent = urlResponse.getContentText()
+        var icsRegex = RegExp("(BEGIN:VCALENDAR.*?END:VCALENDAR)", "s")
+        var urlContent = icsRegex.exec(icsContent);
+        if(urlContent == null) {
+          // Microsoft Outlook has a bug that sometimes results in incorrectly formatted ics files. This tries to fix that problem.
+          icsContent = icsContent.replaceAll(/(?<!END:VTIMEZONE[\r\n]+)BEGIN:VEVENT/g, 'END:VEVENT\nBEGIN:VEVENT') + 'END:VCALENDAR'
+          urlContent = icsRegex.exec(icsContent)
+          if (urlContent == null) {
+            Logger.log("[ERROR] Incorrect ics/ical URL: " + url)
+            return
+          }
+          Logger.log("[WARNING] Microsoft is incorrectly formatting ics/ical at: " + url)
         }
-        else{
-          result.push([urlContent[0], colorId]);
-          return;
-        }
+        result.push([urlContent[0], colorId]);
+        return; 
       }
       else{ //Throw here to make callWithBackoff run again
-        throw "Error: Encountered HTTP error " + urlResponse.getResponseCode() + " when accessing " + url;
+        throw "Error: Encountered HTTP error " + urlResponse.getResponseCode() + " when accessing " + url; 
       }
     }, defaultMaxRetries);
   }
-
+  
   return result;
 }
 


### PR DESCRIPTION
Microsoft Outlook has a bug that sometimes results in incorrectly formatted ics files:
- The ics file lacks an `END:VCALENDAR` line at the end of the file.
- Only the last VEVENT is properly ended with a `END:VEVENT` line.

If unfixed, this error will result in `fetchSourceCalendars()` returning with error `[ERROR] Incorrect ics/ical URL: ` followed by the URL of the broken ics.

After I noticed the bug, I confirmed it on a call with Microsoft support. The support agent told me it would likely take months to fix.

This tries to fix that problem by adding `END:VEVENT` after every VEvent and adding an `END:VCALENDAR` at the end of the file if the original regex match fails. to find `END:VCALENDAR`.