### PR TITLE
Overwrite parent calendar name

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -6,7 +6,7 @@
 * 1) Make a copy:
 *      New Interface: Go to the project overview icon on the left (looks like this: ⓘ), then click the "copy" icon on the top right (looks like two files on top of each other)
 *      Old Interface: Click in the menu "File" > "Make a copy..." and make a copy to your Google Drive
-* 2) Settings: Change lines 24-64 to be the settings that you want to use
+* 2) Settings: Change lines 24-67 to be the settings that you want to use
 * 3) Install:
 *      New Interface: Make sure your toolbar says "install" to the right of "Debug", then click "Run"
 *      Old Interface: Click "Run" > "Run function" > "install"
@@ -28,16 +28,19 @@ var sourceCalendars = [
 
   // Or with additional Options:
   // - colorId: Colors of the Events with the following mapping https://developers.google.com/apps-script/reference/calendar/event-color
+  // - calendarName: Alternative name for the parent calendar
   // for instance:
   // ["https://p24-calendars.icloud.com/holidays/us_en.ics", "US Holidays", {
   //   colorId: "1",
+  //   calendarName: 'Parent Calendar Name'
   // }]
 
   ["icsUrl1", "targetCalendar1", {
     colorId: "1",
+    calendarName: 'Parent Calendar Name 1'
   }],
   ["icsUrl2", "targetCalendar2", {
-    colorId: "4"
+    calendarName: 'Parent Calendar Name 2'
   }],
   ["icsUrl3", "targetCalendar3"],
 ];

--- a/Code.gs
+++ b/Code.gs
@@ -6,7 +6,7 @@
 * 1) Make a copy:
 *      New Interface: Go to the project overview icon on the left (looks like this: ⓘ), then click the "copy" icon on the top right (looks like two files on top of each other)
 *      Old Interface: Click in the menu "File" > "Make a copy..." and make a copy to your Google Drive
-* 2) Settings: Change lines 24-50 to be the settings that you want to use
+* 2) Settings: Change lines 24-64 to be the settings that you want to use
 * 3) Install:
 *      New Interface: Make sure your toolbar says "install" to the right of "Debug", then click "Run"
 *      Old Interface: Click "Run" > "Run function" > "install"
@@ -21,14 +21,25 @@
 *=========================================
 */
 
-var sourceCalendars = [                // The ics/ical urls that you want to get events from along with their target calendars (list a new row for each mapping of ICS url to Google Calendar)
-                                       // For instance: ["https://p24-calendars.icloud.com/holidays/us_en.ics", "US Holidays"]
-                                       // Or with colors following mapping https://developers.google.com/apps-script/reference/calendar/event-color,
-                                       // for instance: ["https://p24-calendars.icloud.com/holidays/us_en.ics", "US Holidays", "11"]
-  ["icsUrl1", "targetCalendar1"],
-  ["icsUrl2", "targetCalendar2"],
-  ["icsUrl3", "targetCalendar1"]
+var sourceCalendars = [
 
+  // The ics/ical urls that you want to get events from along with their target calendars (list a new row for each mapping of ICS url to Google Calendar)
+  // For instance: ["https://p24-calendars.icloud.com/holidays/us_en.ics", "US Holidays"]
+
+  // Or with additional Options:
+  // - colorId: Colors of the Events with the following mapping https://developers.google.com/apps-script/reference/calendar/event-color
+  // for instance:
+  // ["https://p24-calendars.icloud.com/holidays/us_en.ics", "US Holidays", {
+  //   colorId: "1",
+  // }]
+
+  ["icsUrl1", "targetCalendar1", {
+    colorId: "1",
+  }],
+  ["icsUrl2", "targetCalendar2", {
+    colorId: "4"
+  }],
+  ["icsUrl3", "targetCalendar3"],
 ];
 
 var howFrequent = 15;                     // What interval (minutes) to run this script on to check for new events.  Any integer can be used, but will be rounded up to 5, 10, 15, 30 or to the nearest hour after that.. 60, 120, etc. 1440 (24 hours) is the maximum value.  Anything above that will be replaced with 1440.

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -206,6 +206,7 @@ function parseResponses(responses){
   for (var itm of responses){
     var resp = itm[0];
     var colorId = itm[1].colorId && itm[1].colorId;
+    var calendarName = itm[1].calendarName && itm[1].calendarName;
     var jcalData = ICAL.parse(resp);
     var component = new ICAL.Component(jcalData);
 
@@ -219,9 +220,15 @@ function parseResponses(responses){
     if (colorId != undefined)
       allEvents.forEach(function(event){event.addPropertyWithValue("color", colorId);});
 
-    var calName = component.getFirstPropertyValue("x-wr-calname") || component.getFirstPropertyValue("name");
-    if (calName != null)
-      allEvents.forEach(function(event){event.addPropertyWithValue("parentCal", calName); });
+    if (calendarName != undefined) {
+      allEvents.forEach(function(event){event.addPropertyWithValue("parentCal", calendarName); });
+    }
+    else {
+      var calName = component.getFirstPropertyValue("x-wr-calname") || component.getFirstPropertyValue("name");
+      if (calName != null) {
+        allEvents.forEach(function(event){event.addPropertyWithValue("parentCal", calName); });
+      }
+    }
 
     result = [].concat(allEvents, result);
   }

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -205,8 +205,6 @@ function parseResponses(responses){
   var result = [];
   for (var itm of responses){
     var resp = itm[0];
-    var colorId = itm[1].colorId && itm[1].colorId;
-    var calendarName = itm[1].calendarName && itm[1].calendarName;
     var jcalData = ICAL.parse(resp);
     var component = new ICAL.Component(jcalData);
 
@@ -216,18 +214,14 @@ function parseResponses(responses){
       ICAL.TimezoneService.register(tz);
     }
 
+    var colorId = itm[1] && itm[1].colorId
     var allEvents = component.getAllSubcomponents("vevent");
     if (colorId != undefined)
       allEvents.forEach(function(event){event.addPropertyWithValue("color", colorId);});
 
-    if (calendarName != undefined) {
-      allEvents.forEach(function(event){event.addPropertyWithValue("parentCal", calendarName); });
-    }
-    else {
-      var calName = component.getFirstPropertyValue("x-wr-calname") || component.getFirstPropertyValue("name");
-      if (calName != null) {
-        allEvents.forEach(function(event){event.addPropertyWithValue("parentCal", calName); });
-      }
+    var calName = (itm[1] && itm[1].calendarName) || component.getFirstPropertyValue("x-wr-calname") || component.getFirstPropertyValue("name");
+    if (calName != null) {
+      component.getAllSubcomponents("vevent").forEach(function(event){event.addPropertyWithValue("parentCal", calName); });
     }
 
     result = [].concat(allEvents, result);

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -205,7 +205,7 @@ function parseResponses(responses){
   var result = [];
   for (var itm of responses){
     var resp = itm[0];
-    var colorId = itm[1];
+    var colorId = itm[1].colorId && itm[1].colorId;
     var jcalData = ICAL.parse(resp);
     var component = new ICAL.Component(jcalData);
 


### PR DESCRIPTION
Added the option to change the parent calendar name if wanted.(#366)

### Additional Changes
- Optional Arguments in Object instead of Array (makes Future development easier)

### Why
- Some calendars don't have a Calendar Name or the names can't be changed by a user. This PR enables Users to change the Parent Calendar name, when they want the 'new' Events to be prefixed.