### PR TITLE
Improve reliability of source calendar retrieval by enabling retries

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -145,6 +145,9 @@ var addedEvents = [];
 var modifiedEvents = [];
 var removedEvents = [];
 
+// Syncing logic can set this to true to cause the Google Apps Script "Executions" dashboard to report failure
+var reportOverallFailure = false;
+
 function startSync(){
   if (PropertiesService.getUserProperties().getProperty('LastRun') > 0 && (new Date().getTime() - PropertiesService.getUserProperties().getProperty('LastRun')) < 360000) {
     Logger.log("Another iteration is currently running! Exiting...");
@@ -249,4 +252,10 @@ function startSync(){
   }
   Logger.log("Sync finished!");
   PropertiesService.getUserProperties().setProperty('LastRun', 0);
+
+  if (reportOverallFailure) {
+    // Cause the Google Apps Script "Executions" dashboard to show a failure
+    // (the message text does not seem to be logged anywhere)
+    throw new Error('The sync operation produced errors. See log for details.');
+  }
 }


### PR DESCRIPTION
I was having problems where my entire calendar would get deleted temporarily, only to be recreated an hour later, due to intermittent HTTP errors being reported by the calendar source.  It is the same issue discussed in #343.

## Related work

PR #392 tries to solve this same problem by silently skipping sync when such errors occur.  I'm uncomfortable with that solution, because I would prefer "obviously wrong" (entire calendar is missing) versus "deceptively wrong" (calendar looks okay but is actually telling me wrong information because it has stopped syncing).  Skipping sync would be a good solution if we ALSO provided better mechanism for communicating problems, for example email notifications.  Ideally we should pursue that.

## A different approach

But then I found a superior fix:  This PR completely solves the root cause in my case.  That is why I have not invested the time to investigate better error notifications.  For my own purposes at least, this PR entirely eliminated the need for PR #392.

Fixes #343

## What I changed

1. **Track the failures.** If an HTTP request ultimately fails (excluding success after retrying), throw a top-level exception so that the Google Apps Script "Executions" dashboard reports the execution as failing.  Example shown below:

    ![image](https://github.com/derekantrican/GAS-ICS-Sync/assets/4673363/44074f62-6333-41b4-9b55-6c50f7e33a61)

2. **Reattempt HTTP requests.** Improve `callWithBackoff()` so that it retries HTTP requests for all status codes that are known to be intermittent problems.  

With these changes, I can see that the failures are no longer occurring.  The longest reattempt took 8 tries over 14 seconds, as seen in this log:

![image](https://github.com/derekantrican/GAS-ICS-Sync/assets/4673363/ed795523-b02b-4232-b39e-f102dee8cfb3)

But since yesterday, every execution ultimately succeeded. 👍