### PR TITLE
Omit empty sections from email summary

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -1190,7 +1190,16 @@ function sendSummary() {
   var subject;
   var body;
 
-  var subject = `${customEmailSubject ? customEmailSubject : "GAS-ICS-Sync Execution Summary"}: ${addedEvents.length} new, ${modifiedEvents.length} modified, ${removedEvents.length} deleted`;
+  var changeSummary = [
+    { events: addedEvents, label: 'new' },
+    { events: modifiedEvents, label: 'modified' },
+    { events: removedEvents, label: 'deleted' }
+  ]
+  .filter(x => x.events.length)
+  .map(x => `${x.events.length} ${x.label}`)
+  .join(", ");
+  
+  var subject = `${customEmailSubject ? customEmailSubject : "GAS-ICS-Sync Execution Summary"}: ${changeSummary}`;
   addedEvents = condenseCalendarMap(addedEvents);
   modifiedEvents = condenseCalendarMap(modifiedEvents);
   removedEvents = condenseCalendarMap(removedEvents);


### PR DESCRIPTION
This omits empty change sections from the email summary, avoiding clutter in the summary. For example, if there are 5 new events, 0 modified and 2 deleted, the summary will be `5 new, 2 deleted` rather than `5 new, 0 modified, 2 deleted`.