### PR TITLE
fix: filter out cancelled events to prevent Invalid start time errors

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -196,6 +196,8 @@ function startSync(){
           calendarEvents = [].concat(calendarEvents, eventList.items);
       }
       Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
+      // Filter out cancelled events to prevent "Invalid start time" errors
+      calendarEvents = calendarEvents.filter(e => e.status !== "cancelled");
       for (var i = 0; i < calendarEvents.length; i++){
         if (calendarEvents[i].extendedProperties != null){
           calendarEventsIds[i] = calendarEvents[i].extendedProperties.private["rec-id"] || calendarEvents[i].extendedProperties.private["id"];


### PR DESCRIPTION
Fixes #315

This PR filters out events with status 'cancelled' from the calendarEvents array to prevent 'Invalid start time' errors when the script tries to update them.

The fix adds a simple filter after fetching existing events:
```javascript
calendarEvents = calendarEvents.filter(e => e.status !== "cancelled");
```

This resolves the issue where recurring events with 'cancelled' status were causing sync failures.