### PR TITLE
Skip cancelled existing calendar events

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -195,6 +195,13 @@ function startSync(){
         if (eventList != null)
           calendarEvents = [].concat(calendarEvents, eventList.items);
       }
+      var calendarEventsCount = calendarEvents.length;
+      calendarEvents = calendarEvents.filter(function(event) {
+        return event.status !== "cancelled";
+      });
+      if (calendarEvents.length != calendarEventsCount)
+        Logger.log("Skipped " + (calendarEventsCount - calendarEvents.length) + " cancelled existing events from " + targetCalendarName);
+
       Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
       for (var i = 0; i < calendarEvents.length; i++){
         if (calendarEvents[i].extendedProperties != null){


### PR DESCRIPTION
## Summary\n- filter cancelled existing Google Calendar events before building the ID lookup used for updates\n- log how many cancelled events were skipped when this edge case occurs\n\n## Why\nGoogle Calendar can still return cancelled recurring-event instances in some edge cases even when listing with showDeleted=false. If one of those cancelled events matches an incoming ICS event, updating it can fail with `Invalid start time`.\n\nFixes #315\n\n## Validation\n- `cp Code.gs /tmp/gas-ics-Code.js && node --check /tmp/gas-ics-Code.js`