### PR TITLE
Skip cancelled Google Calendar events before sync matching

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -195,7 +195,12 @@ function startSync(){
         if (eventList != null)
           calendarEvents = [].concat(calendarEvents, eventList.items);
       }
-      Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
+      var fetchedCalendarEventsCount = calendarEvents.length;
+      calendarEvents = calendarEvents.filter(function(event){
+        return event != null && (event.status == null || event.status.toString().toLowerCase() != "cancelled");
+      });
+      var skippedCancelledEventsCount = fetchedCalendarEventsCount - calendarEvents.length;
+      Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName + (skippedCancelledEventsCount > 0 ? " (" + skippedCancelledEventsCount + " cancelled skipped)" : ""));
       for (var i = 0; i < calendarEvents.length; i++){
         if (calendarEvents[i].extendedProperties != null){
           calendarEventsIds[i] = calendarEvents[i].extendedProperties.private["rec-id"] || calendarEvents[i].extendedProperties.private["id"];


### PR DESCRIPTION
Fixes https://github.com/derekantrican/GAS-ICS-Sync/issues/315

### Summary

- Filter existing Google Calendar events with `status: "cancelled"` before building the `calendarEventsIds` matching array.
- Keep confirmed/tentative/statusless events eligible for normal update matching.
- Log how many cancelled existing events were skipped when any are present.

### Why

The sync fetches existing Google Calendar events with `showDeleted: false`, but issue discussion reports that cancelled events can still appear in this result set. If a cancelled event has the same extended private ID as an incoming ICS event, the sync attempts `Calendar.Events.update(...)` against the cancelled event and can fail with `Invalid start time`.

Filtering cancelled existing events before the ID/MD5 arrays are built prevents them from becoming update candidates.

### Verification

```sh
node --check --input-type=commonjs < Code.gs
node --check --input-type=commonjs < Helpers.gs
git diff --check HEAD~1 HEAD
node -e 'const events=[{id:"1",status:"confirmed"},{id:"2",status:"cancelled"},{id:"3"},null,undefined,{id:"4",status:"CANCELLED"}]; const filtered=events.filter(function(event){return event != null && (event.status == null || event.status.toString().toLowerCase() != "cancelled");}); console.log(JSON.stringify(filtered.map(e => e.id))); if (JSON.stringify(filtered.map(e => e.id)) !== JSON.stringify(["1","3"])) process.exit(1);'
```

All commands passed locally.
