### PR TITLE
Fix: Explicit UTF-8 encoding in getContentText() to handle special ch...

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -137,7 +137,7 @@ function fetchSourceCalendars(sourceCalendarURLs){
       callWithBackoff(function() {
         var urlResponse = UrlFetchApp.fetch(url, { 'validateHttpsCertificates' : false, 'muteHttpExceptions' : true });
         if (urlResponse.getResponseCode() == 200){
-          var icsContent = urlResponse.getContentText()
+          var icsContent = urlResponse.getContentText("UTF-8")
           const icsRegex = RegExp("(BEGIN:VCALENDAR.*?END:VCALENDAR)", "s")
           var urlContent = icsRegex.exec(icsContent);
           if (urlContent == null){


### PR DESCRIPTION
Fix: Explicit UTF-8 encoding in getContentText() to handle special characters

Without specifying the charset, Apps Script infers encoding from the HTTP 
response header. If the iCal source (e.g. Smoobu) omits or misreports the 
charset, non-ASCII characters (e.g. Đ, đ, ć, ñ, ø) cause events to be 
silently dropped during parsing.

Fix: pass "UTF-8" explicitly to getContentText() in fetchSourceCalendars().

Reproducer: iCal feed containing a guest name with Unicode characters 
(e.g. "Đerđov") – event not synced, no error in execution log.