### PR TITLE
Filter cancelled calendar events before sync updates

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -195,6 +195,18 @@ function startSync(){
         if (eventList != null)
           calendarEvents = [].concat(calendarEvents, eventList.items);
       }
+      // Some recurring-event edge cases can still return cancelled events even
+      // with showDeleted=false; these cannot be updated and may throw
+      // "Invalid start time" when treated as active events.
+      var activeCalendarEvents = calendarEvents.filter(function(event){
+        return event.status !== "cancelled";
+      });
+      if (activeCalendarEvents.length !== calendarEvents.length) {
+        Logger.log(
+          "Filtered " + (calendarEvents.length - activeCalendarEvents.length) + " cancelled existing events before sync"
+        );
+      }
+      calendarEvents = activeCalendarEvents;
       Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
       for (var i = 0; i < calendarEvents.length; i++){
         if (calendarEvents[i].extendedProperties != null){


### PR DESCRIPTION
This PR addresses issue #315 (`Invalid start time` on `calendar.events.update`) by excluding cancelled Google events from the in-memory update set.

## What changed
- After loading existing calendar events (`showDeleted: false`), filter out any events whose `status` is `cancelled`.
- Add a log line that reports how many cancelled events were filtered.

## Why
Some recurring-event edge cases can still return cancelled events even with `showDeleted=false`. When those are treated as active and passed into update logic, they can trigger `Invalid start time` failures.

## Scope
- Minimal runtime behavior change in `startSync` event-loading flow only.
- No config changes.

## Validation
- Static logic validation against issue repro details and existing sync flow.
- Change is isolated to existing-event pre-processing before ID/MD5 mapping.

Closes #315
