### PR TITLE
Guard against cancelled existing events causing Invalid start time

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -195,6 +195,18 @@ function startSync(){
         if (eventList != null)
           calendarEvents = [].concat(calendarEvents, eventList.items);
       }
+      // Some recurring-event edge cases can still return cancelled events even
+      // with showDeleted=false; these cannot be updated and may throw
+      // "Invalid start time" when treated as active events.
+      var activeCalendarEvents = calendarEvents.filter(function(event){
+        return event.status !== "cancelled";
+      });
+      if (activeCalendarEvents.length !== calendarEvents.length) {
+        Logger.log(
+          "Filtered " + (calendarEvents.length - activeCalendarEvents.length) + " cancelled existing events before sync"
+        );
+      }
+      calendarEvents = activeCalendarEvents;
       Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
       for (var i = 0; i < calendarEvents.length; i++){
         if (calendarEvents[i].extendedProperties != null){

--- a/Helpers.gs
+++ b/Helpers.gs
@@ -608,6 +608,10 @@ function processEvent(event, calendarTz){
     //------------------------ Send event object to gcal ------------------------
     if (needsUpdate){
       if (modifyExistingEvents){
+        if (calendarEvents[index].status && calendarEvents[index].status.toLowerCase() === "cancelled"){
+          Logger.log("Skipping update for cancelled existing event " + calendarEvents[index].id);
+          return;
+        }
         oldEvent = calendarEvents[index]
         Logger.log("Updating existing event " + newEvent.extendedProperties.private["id"]);
         try{


### PR DESCRIPTION
## Summary
This patch addresses the recurring `Invalid start time` failure reported in #315 when syncing updates against existing Google events that are already `cancelled`.

## What changed
- In `Code.gs` (`startSync`), filter out existing calendar events with `status === "cancelled"` immediately after fetch (with a log count).
- In `Helpers.gs` (`processEvent`), add a second safety guard: if a matched existing event is cancelled, skip `Calendar.Events.update` and log the skip.

## Why this differs from existing fix attempts
There is already a focused filter fix in #526. This PR keeps that idea and adds a second update-path guard to handle edge cases where cancelled events can still appear during update flow.

## Scope
- Minimal change, no behavior changes outside cancelled-event handling.
- No config changes.

## Validation
- Code-path review against issue reproduction context.
- Logs now explicitly show when cancelled existing events are filtered/skipped.
