### PR TITLE
Allow target calendar to match by Calendar ID as well as display name

### DIFF
--- a/Helpers.gs
+++ b/Helpers.gs
@@ -183,8 +183,9 @@ function fetchSourceCalendars(sourceCalendarURLs){
  */
 function setupTargetCalendar(targetCalendarName){
   var targetCalendar = Calendar.CalendarList.list({showHidden: true, maxResults: 250}).items.filter(function(cal) {
-    return ((cal.summaryOverride || cal.summary) == targetCalendarName) &&
-                (cal.accessRole == "owner" || cal.accessRole == "writer");
+    //add Cal.id check for family calendars 
+    return (cal.id == targetCalendarName || (cal.summaryOverride || cal.summary) == targetCalendarName) &&
+            (cal.accessRole == "owner" || cal.accessRole == "writer");
   })[0];
 
   if(targetCalendar == null){


### PR DESCRIPTION
Currently, setupTargetCalendar only matches on summary / summaryOverride. This causes issues when targeting shared calendars (such as Google Family Calendars or renamed secondary calendars) where users specify the calendar ID (...group.calendar.google.com) or when multiple calendars share similar display names.