### PR TITLE
fix: unchecked null from callWithBackoff in target-calendar pagination

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -185,6 +185,18 @@ function startSync(){
         callWithBackoff(function(){
             return Calendar.Events.list(targetCalendarId, {showDeleted: false, privateExtendedProperty: "fromGAS=true", maxResults: 2500});
         }, defaultMaxRetries);
+
+      if (eventList == null){
+        // callWithBackoff gives up and returns null after exhausting retries
+        // instead of throwing (see Helpers.gs), so unlike the try/catch
+        // pattern used elsewhere in this file (#467) for calls that throw,
+        // this needs an explicit null check. Continuing here would crash on
+        // eventList.items with "Cannot read properties of null".
+        Logger.log(`Operation failed with error "Failed to fetch existing events for ${targetCalendarName} after ${defaultMaxRetries} retries"`);
+        reportOverallFailure = true;
+        continue;
+      }
+
       calendarEvents = [].concat(calendarEvents, eventList.items);
       //loop until we received all events
       while(typeof eventList.nextPageToken !== 'undefined'){
@@ -192,8 +204,15 @@ function startSync(){
           return Calendar.Events.list(targetCalendarId, {showDeleted: false, privateExtendedProperty: "fromGAS=true", maxResults: 2500, pageToken: eventList.nextPageToken});
         }, defaultMaxRetries);
 
-        if (eventList != null)
-          calendarEvents = [].concat(calendarEvents, eventList.items);
+        if (eventList == null){
+          // Same failure mode mid-pagination: stop paging instead of crashing
+          // on eventList.nextPageToken on the next loop check.
+          Logger.log(`Operation failed with error "Failed to fetch a page of existing events for ${targetCalendarName} after ${defaultMaxRetries} retries"`);
+          reportOverallFailure = true;
+          break;
+        }
+
+        calendarEvents = [].concat(calendarEvents, eventList.items);
       }
       Logger.log("Fetched " + calendarEvents.length + " existing events from " + targetCalendarName);
       for (var i = 0; i < calendarEvents.length; i++){


### PR DESCRIPTION
While looking at #496 (a crash from an unchecked null after `callWithBackoff` exhausts its retries), I noticed the *source*-calendar fetch path that issue is about (`fetchSourceCalendars`) already handles this correctly today — it's wrapped in try/catch and sets `reportOverallFailure` instead of crashing.

The *target*-calendar fetch path in `startSync` (fetching existing Google Calendar events via `Calendar.Events.list`) has the same unguarded pattern, though: `callWithBackoff` returns `null` after exhausting retries rather than throwing, but both call sites here assume success and dereference `eventList.items`/`eventList.nextPageToken` unconditionally.

This isn't a fix for #496 itself — the exact crash signature there is different and already resolved — but it closes the same class of gap in a path that's still open today.

#467 already applies this repo's established try/catch + reportOverallFailure pattern to the update/insert/remove call sites, for calls that throw. This case has a different failure signal (a null return, not a thrown exception) so needs an explicit check instead, but follows the same reportOverallFailure convention and matching Logger.log phrasing.

### Test plan
- Extracted the pagination logic into a pure function (no GAS globals) and tested 5 scenarios (null on first fetch, null mid-pagination, unchanged success path) with plain Node.js — all pass.
- Confirmed `callWithBackoff`'s null-on-exhaustion behavior directly in Helpers.gs (lines 1294-1319) rather than assuming it.
- Could not test the real `Calendar.Events.list` call itself (needs a live Google account).

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.